### PR TITLE
Update BWTC.js

### DIFF
--- a/src/lib/BWTC.js
+++ b/src/lib/BWTC.js
@@ -15,7 +15,7 @@ var EOF = Stream.EOF;
 var F_PROB_MAX  = 0xFF00;
 var F_PROB_INCR = 0x0100;
 
-BWTC = Object.create(null);
+const BWTC = Object.create(null);
 BWTC.MAGIC = "bwtc";
 BWTC.compressFile = Util.compressFileHelper(BWTC.MAGIC, function(input, output, size, props, finalByte) {
     var encoder = new RangeCoder(output);


### PR DESCRIPTION
Hey @gre 👋 

I am trying to replace `webpack` with `vite.js` in dev mode for Ledger Live Desktop and I encountered an error while trying it out.

The line `BWTC = Object.create(null);` instantiates silently a global variable which is not compatible with [the Javascript Strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#converting_mistakes_into_errors) which is [enabled by default](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#strict_mode_for_modules) when using Javascript modules in a browser.

I think that prefixing the variable with a simple `const` should fix without causing any harm to the rest of the code.